### PR TITLE
Don't return error when resource doesn't exist

### DIFF
--- a/redshift/resource_redshift_database.go
+++ b/redshift/resource_redshift_database.go
@@ -48,7 +48,10 @@ func resourceRedshiftDatabaseExists(d *schema.ResourceData, meta interface{}) (b
 	var name string
 
 	err := client.QueryRow("SELECT datname FROM pg_database_info WHERE datid = $1", d.Id()).Scan(&name)
-	if err != nil {
+	switch {
+	case err == sql.ErrNoRows:
+		return false, nil
+	case err != nil:
 		return false, err
 	}
 	return true, nil

--- a/redshift/resource_redshift_group.go
+++ b/redshift/resource_redshift_group.go
@@ -48,7 +48,10 @@ func resourceRedshiftGroupExists(d *schema.ResourceData, meta interface{}) (b bo
 	var name string
 
 	err := client.QueryRow("SELECT groname FROM pg_group WHERE grosysid = $1", d.Id()).Scan(&name)
-	if err != nil {
+	switch {
+	case err == sql.ErrNoRows:
+		return false, nil
+	case err != nil:
 		return false, err
 	}
 	return true, nil

--- a/redshift/resource_redshift_user.go
+++ b/redshift/resource_redshift_user.go
@@ -74,7 +74,10 @@ func resourceRedshiftUserExists(d *schema.ResourceData, meta interface{}) (b boo
 	var name string
 
 	err := client.QueryRow("SELECT usename FROM pg_user_info WHERE usesysid = $1", d.Id()).Scan(&name)
-	if err != nil {
+	switch {
+	case err == sql.ErrNoRows:
+		return false, nil
+	case err != nil:
 		return false, err
 	}
 	return true, nil


### PR DESCRIPTION
If a redshift resource created by terraform was removed by terraform it caused the redshift provider to crash.

This is how the exists functions work in the postgres provider.