### PR TITLE
Fail gracefully when db connection fails

### DIFF
--- a/redshift/config.go
+++ b/redshift/config.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"fmt"
 	_ "github.com/lib/pq"
-	"log"
 )
 
 // Config holds API and APP keys to authenticate to Datadog.
@@ -19,11 +18,11 @@ type Config struct {
 
 type Client struct {
 	config Config
-	db *sql.DB
+	db     *sql.DB
 }
 
 // New redshift client
-func (c *Config) Client() *Client {
+func (c *Config) Client() (*Client, error) {
 
 	conninfo := fmt.Sprintf("sslmode=%v user=%v password=%v host=%v port=%v dbname=%v",
 		c.sslmode,
@@ -34,16 +33,17 @@ func (c *Config) Client() *Client {
 		c.database)
 
 	db, err := sql.Open("postgres", conninfo)
-
 	if err != nil {
-		log.Fatal(err)
-		panic(err)
+		db.Close()
+		return nil, err
 	}
 
-	return &Client{
+	client := Client{
 		config: *c,
 		db:     db,
 	}
+
+	return &client, nil
 }
 
 //When do we close the connection?

--- a/redshift/provider.go
+++ b/redshift/provider.go
@@ -3,6 +3,8 @@ package redshift
 import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
+
+	"fmt"
 	"log"
 )
 
@@ -64,15 +66,17 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	}
 
 	log.Println("[INFO] Initializing Redshift client")
-	client := config.Client()
+	client, err := config.Client()
+	if err != nil {
+		return nil, err
+	}
+
 	db := client.db
 
-	//Test the connection
-	err := db.Ping()
-
-	if err != nil {
-		log.Println("[ERROR] Could not establish Redshift connection with credentials")
-		panic(err.Error()) // proper error handling instead of panic
+	// DB connection is not opened until the first query.
+	// Test the connection
+	if err = db.Ping(); err != nil {
+		return nil, fmt.Errorf("Redshift connection error: %v", err)
 	}
 
 	return client, nil


### PR DESCRIPTION
Should close issue #2.

Instead of `panic`ing and dying give the user some feedback about what the problem is when redshift connection fails.

    * provider.redshift: Redshift connection error: dial tcp: lookup made-up-hostname.com: no such host