### PR TITLE
Make error visible when user already exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.dll
 *.so
 *.dylib
+terraform-provider-redshift
 
 # Test binary, build with `go test -c`
 *.test

--- a/redshift/resource_redshift_user.go
+++ b/redshift/resource_redshift_user.go
@@ -126,8 +126,7 @@ func resourceRedshiftUserCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	if _, err := tx.Exec(createStatement); err != nil {
-		log.Fatal(err)
-		return err
+		return fmt.Errorf("Could not create redshift user: %s", err)
 	}
 
 	log.Print("User created, waiting 5 seconds for propagation")


### PR DESCRIPTION
The provider plugin was crashing when attempting to create users if they already existed.

With this change the terraform user gets a more readable error, something like...

    * redshift_user.database_users.3: Could not create redshift group: pq: user "joebloggs" already exists