### PR TITLE
Fixing linter warnings

### DIFF
--- a/redshift/resource_redshift_database.go
+++ b/redshift/resource_redshift_database.go
@@ -170,13 +170,13 @@ func resourceRedshiftDatabaseUpdate(d *schema.ResourceData, meta interface{}) er
 
 	err := readRedshiftDatabase(d, redshiftClient)
 
-	if err == nil {
-		tx.Commit()
-		return nil
-	} else {
+	if err != nil {
 		tx.Rollback()
 		return err
 	}
+
+	tx.Commit()
+	return nil
 }
 
 func resourceRedshiftDatabaseDelete(d *schema.ResourceData, meta interface{}) error {

--- a/redshift/resource_redshift_group.go
+++ b/redshift/resource_redshift_group.go
@@ -94,13 +94,13 @@ func resourceRedshiftGroupCreate(d *schema.ResourceData, meta interface{}) error
 
 	readErr := readRedshiftGroup(d, tx)
 
-	if readErr == nil {
-		tx.Commit()
-		return nil
-	} else {
+	if readErr != nil {
 		tx.Rollback()
 		return readErr
 	}
+
+	tx.Commit()
+	return nil
 }
 
 func resourceRedshiftGroupRead(d *schema.ResourceData, meta interface{}) error {
@@ -115,13 +115,13 @@ func resourceRedshiftGroupRead(d *schema.ResourceData, meta interface{}) error {
 
 	err := readRedshiftGroup(d, tx)
 
-	if err == nil {
-		tx.Commit()
-		return nil
-	} else {
+	if err != nil {
 		tx.Rollback()
 		return err
 	}
+
+	tx.Commit()
+	return nil
 }
 
 func readRedshiftGroup(d *schema.ResourceData, tx *sql.Tx) error {
@@ -206,13 +206,13 @@ func resourceRedshiftGroupUpdate(d *schema.ResourceData, meta interface{}) error
 
 	err := readRedshiftGroup(d, tx)
 
-	if err == nil {
-		tx.Commit()
-		return nil
-	} else {
+	if err != nil {
 		tx.Rollback()
 		return err
 	}
+
+	tx.Commit()
+	return nil
 }
 
 func resourceRedshiftGroupDelete(d *schema.ResourceData, meta interface{}) error {

--- a/redshift/resource_redshift_schema.go
+++ b/redshift/resource_redshift_schema.go
@@ -52,7 +52,7 @@ func resourceRedshiftSchemaExists(d *schema.ResourceData, meta interface{}) (b b
 
 	var name string
 
-	var existenceQuery string = "SELECT nspname FROM pg_namespace WHERE oid = $1"
+	var existenceQuery = "SELECT nspname FROM pg_namespace WHERE oid = $1"
 
 	log.Print("Does schema exist query: " + existenceQuery + ", " + d.Id())
 

--- a/redshift/resource_redshift_schema.go
+++ b/redshift/resource_redshift_schema.go
@@ -117,18 +117,18 @@ func resourceRedshiftSchemaRead(d *schema.ResourceData, meta interface{}) error 
 
 func readRedshiftSchema(d *schema.ResourceData, db *sql.DB) error {
 	var (
-		schema_name string
-		owner       int
+		schemaName string
+		owner      int
 	)
 
-	err := db.QueryRow("select nspname, nspowner from pg_namespace where oid = $1", d.Id()).Scan(&schema_name, &owner)
+	err := db.QueryRow("select nspname, nspowner from pg_namespace where oid = $1", d.Id()).Scan(&schemaName, &owner)
 
 	if err != nil {
 		log.Fatal(err)
 		return err
 	}
 
-	d.Set("schema_name", schema_name)
+	d.Set("schema_name", schemaName)
 	d.Set("owner", owner)
 
 	return nil

--- a/redshift/resource_redshift_schema.go
+++ b/redshift/resource_redshift_schema.go
@@ -163,13 +163,13 @@ func resourceRedshiftSchemaUpdate(d *schema.ResourceData, meta interface{}) erro
 
 	err := readRedshiftSchema(d, redshiftClient)
 
-	if err == nil {
-		tx.Commit()
-		return nil
-	} else {
+	if err != nil {
 		tx.Rollback()
 		return err
 	}
+
+	tx.Commit()
+	return nil
 }
 
 func resourceRedshiftSchemaDelete(d *schema.ResourceData, meta interface{}) error {

--- a/redshift/resource_redshift_user.go
+++ b/redshift/resource_redshift_user.go
@@ -150,14 +150,13 @@ func resourceRedshiftUserCreate(d *schema.ResourceData, meta interface{}) error 
 
 	readErr := readRedshiftUser(d, tx)
 
-	if readErr == nil {
-		tx.Commit()
-		return nil
-	} else {
+	if readErr != nil {
 		tx.Rollback()
 		return readErr
 	}
 
+	tx.Commit()
+	return nil
 }
 
 func resourceRedshiftUserRead(d *schema.ResourceData, meta interface{}) error {
@@ -172,13 +171,13 @@ func resourceRedshiftUserRead(d *schema.ResourceData, meta interface{}) error {
 
 	err := readRedshiftUser(d, tx)
 
-	if err == nil {
-		tx.Commit()
-		return nil
-	} else {
+	if err != nil {
 		tx.Rollback()
 		return err
 	}
+
+	tx.Commit()
+	return nil
 }
 
 func readRedshiftUser(d *schema.ResourceData, tx *sql.Tx) error {
@@ -292,37 +291,34 @@ func resourceRedshiftUserUpdate(d *schema.ResourceData, meta interface{}) error 
 
 	err := readRedshiftUser(d, tx)
 
-	if err == nil {
-		tx.Commit()
-		return nil
-	} else {
+	if err != nil {
 		tx.Rollback()
 		return err
 	}
+
+	tx.Commit()
+	return nil
 }
 
 func resetPassword(tx *sql.Tx, d *schema.ResourceData, username string) error {
 
 	if v, ok := d.GetOk("password_disabled"); ok && v.(bool) {
-
 		var disablePasswordQuery = "alter user " + username + " password disable"
 
 		if _, err := tx.Exec(disablePasswordQuery); err != nil {
 			return err
 		}
 		return nil
-
-	} else {
-		var resetPasswordQuery = "alter user " + username + " password '" + d.Get("password").(string) + "' "
-		if v, ok := d.GetOk("valid_until"); ok {
-			resetPasswordQuery += " VALID UNTIL '" + v.(string) + "'"
-
-		}
-		if _, err := tx.Exec(resetPasswordQuery); err != nil {
-			return err
-		}
-		return nil
 	}
+
+	var resetPasswordQuery = "alter user " + username + " password '" + d.Get("password").(string) + "' "
+	if v, ok := d.GetOk("valid_until"); ok {
+		resetPasswordQuery += " VALID UNTIL '" + v.(string) + "'"
+	}
+	if _, err := tx.Exec(resetPasswordQuery); err != nil {
+		return err
+	}
+	return nil
 }
 
 func resourceRedshiftUserDelete(d *schema.ResourceData, meta interface{}) error {
@@ -439,13 +435,13 @@ func resourceRedshiftUserDelete(d *schema.ResourceData, meta interface{}) error 
 
 	_, dropUserErr := tx.Exec("DROP USER " + d.Get("username").(string))
 
-	if dropUserErr == nil {
-		tx.Commit()
-		return nil
-	} else {
+	if dropUserErr != nil {
 		tx.Rollback()
 		return dropUserErr
 	}
+
+	tx.Commit()
+	return nil
 }
 
 func resourceRedshiftUserImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {

--- a/redshift/resource_redshift_user.go
+++ b/redshift/resource_redshift_user.go
@@ -190,7 +190,7 @@ func readRedshiftUser(d *schema.ResourceData, tx *sql.Tx) error {
 		useconnlimit sql.NullString
 	)
 
-	var readUserQuery string = "select usename, usecreatedb, usesuper, valuntil, useconnlimit " +
+	var readUserQuery = "select usename, usecreatedb, usesuper, valuntil, useconnlimit " +
 		"from pg_user_info where usesysid = $1"
 
 	log.Print("Reading redshift user with query: " + readUserQuery)
@@ -344,7 +344,7 @@ func resourceRedshiftUserDelete(d *schema.ResourceData, meta interface{}) error 
 	// See some discussion her: https://dba.stackexchange.com/questions/143938/drop-user-in-redshift-which-has-privilege-on-some-object
 	//
 	// Derived from https://github.com/awslabs/amazon-redshift-utils/blob/master/src/AdminViews/v_find_dropuser_objs.sql
-	var reassignOwnerGenerator string = `SELECT owner.ddl
+	var reassignOwnerGenerator = `SELECT owner.ddl
 		FROM (
 				-- Functions owned by the user
 				SELECT pgu.usesysid,
@@ -467,7 +467,7 @@ func GetUsersnamesForUsesysid(q Queryer, usersIdsInterface []interface{}) []stri
 	var usernames []string
 
 	//I couldnt figure out how to pass a slice to go sql
-	var selectUserQuery string = fmt.Sprintf("select usename from pg_user_info where usesysid in (%s)", strings.Trim(strings.Join(strings.Fields(fmt.Sprint(usersIds)), ","), "[]"))
+	var selectUserQuery = fmt.Sprintf("select usename from pg_user_info where usesysid in (%s)", strings.Trim(strings.Join(strings.Fields(fmt.Sprint(usersIds)), ","), "[]"))
 
 	log.Print("Select user query: " + selectUserQuery)
 

--- a/redshift/resource_redshift_user.go
+++ b/redshift/resource_redshift_user.go
@@ -303,22 +303,25 @@ func resourceRedshiftUserUpdate(d *schema.ResourceData, meta interface{}) error 
 func resetPassword(tx *sql.Tx, d *schema.ResourceData, username string) error {
 
 	if v, ok := d.GetOk("password_disabled"); ok && v.(bool) {
+
 		var disablePasswordQuery = "alter user " + username + " password disable"
 
 		if _, err := tx.Exec(disablePasswordQuery); err != nil {
 			return err
 		}
 		return nil
-	}
 
-	var resetPasswordQuery = "alter user " + username + " password '" + d.Get("password").(string) + "' "
-	if v, ok := d.GetOk("valid_until"); ok {
-		resetPasswordQuery += " VALID UNTIL '" + v.(string) + "'"
+	} else {
+		var resetPasswordQuery = "alter user " + username + " password '" + d.Get("password").(string) + "' "
+		if v, ok := d.GetOk("valid_until"); ok {
+			resetPasswordQuery += " VALID UNTIL '" + v.(string) + "'"
+
+		}
+		if _, err := tx.Exec(resetPasswordQuery); err != nil {
+			return err
+		}
+		return nil
 	}
-	if _, err := tx.Exec(resetPasswordQuery); err != nil {
-		return err
-	}
-	return nil
 }
 
 func resourceRedshiftUserDelete(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
I thought I'd already sent this PR, so if it is somehow duplicated sorry about that.

I was looking at the [go report card](https://goreportcard.com/report/github.com/frankfarrell/terraform-provider-redshift) for the repository and thought I'd try to reduce the number of linter warnings.

 * Rearrange if blocks where if and else both `return`.
 * Changed underscored variable names to use camel case.
 * Remove type from declarations where type can be inferred.