### PR TITLE
Fix small typo in grant all query

### DIFF
--- a/redshift/resource_redshift_schema_group_privilege.go
+++ b/redshift/resource_redshift_schema_group_privilege.go
@@ -3,9 +3,10 @@ package redshift
 import (
 	"database/sql"
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
 	"log"
 	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 //https://docs.aws.amazon.com/redshift/latest/dg/r_GRANT.html
@@ -309,7 +310,7 @@ func updatePrivilege(tx *sql.Tx, d *schema.ResourceData, attribute string, privi
 	}
 
 	if d.Get(attribute).(bool) {
-		if _, err := tx.Exec("GRANT " + privilege + " ALL TABLES IN SCHEMA " + schemaName + " TO  GROUP " + groupName); err != nil {
+		if _, err := tx.Exec("GRANT " + privilege + " ON ALL TABLES IN SCHEMA " + schemaName + " TO  GROUP " + groupName); err != nil {
 			return err
 		}
 		if _, err := tx.Exec("ALTER DEFAULT PRIVILEGES IN SCHEMA " + schemaName + " GRANT " + privilege + " ON TABLES TO GROUP " + groupName); err != nil {


### PR DESCRIPTION
When executing an update to group schema privilege I encountered the following error: 
```
* redshift_group_schema_privilege.testgroup_testchema_privileges: 1 error(s) occurred:

* redshift_group_schema_privilege.testgroup_testchema_privileges: pq: syntax error at or near "ALL"
```

This error occurs when the privilege attribute is changed from `false` to `true`. From the AWS [Redshift docs](https://docs.aws.amazon.com/redshift/latest/dg/r_GRANT.html) we can confirm that when granting all tables schema privileges the syntax requires `ON`. 

After making the change I compiled the plugin and tested locally. I was able to update the privilege successfully:
```
redshift_group_schema_privilege.testgroup_testchema_privileges: Modifying... (ID: 100114_100)
  insert: "false" => "true"
redshift_group_schema_privilege.testgroup_testchema_privileges: Modifications complete after 1s (ID: 100114_100)

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```
