### PR TITLE
Change log.Fatal to log.Print

### DIFF
--- a/redshift/resource_redshift_database.go
+++ b/redshift/resource_redshift_database.go
@@ -77,7 +77,7 @@ func resourceRedshiftDatabaseCreate(d *schema.ResourceData, meta interface{}) er
 	log.Print("Create database statement: " + createStatement)
 
 	if _, err := redshiftClient.Exec(createStatement); err != nil {
-		log.Fatal(err)
+		log.Print(err)
 		return err
 	}
 
@@ -88,7 +88,7 @@ func resourceRedshiftDatabaseCreate(d *schema.ResourceData, meta interface{}) er
 	err := redshiftClient.QueryRow("SELECT datid FROM pg_database_info WHERE datname = $1", d.Get("database_name").(string)).Scan(&datid)
 
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
 		return err
 	}
 
@@ -118,7 +118,7 @@ func readRedshiftDatabase(d *schema.ResourceData, db *sql.DB) error {
 	err := db.QueryRow("select datname, datdba, datconnlimit from pg_database_info where datid = $1", d.Id()).Scan(&databasename, &owner, &connlimit)
 
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
 		return err
 	}
 
@@ -186,7 +186,7 @@ func resourceRedshiftDatabaseDelete(d *schema.ResourceData, meta interface{}) er
 	_, err := client.Exec("drop database " + d.Get("database_name").(string))
 
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
 		return err
 	}
 

--- a/redshift/resource_redshift_group.go
+++ b/redshift/resource_redshift_group.go
@@ -133,7 +133,7 @@ func readRedshiftGroup(d *schema.ResourceData, tx *sql.Tx) error {
 	err := tx.QueryRow("SELECT groname, grolist FROM pg_group WHERE grosysid = $1", d.Id()).Scan(&groupname, &users)
 
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
 		return err
 	}
 
@@ -240,7 +240,7 @@ func resourceRedshiftGroupDelete(d *schema.ResourceData, meta interface{}) error
 	_, err := client.Exec("DROP GROUP " + d.Get("group_name").(string))
 
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
 		return err
 	}
 

--- a/redshift/resource_redshift_schema.go
+++ b/redshift/resource_redshift_schema.go
@@ -81,7 +81,7 @@ func resourceRedshiftSchemaCreate(d *schema.ResourceData, meta interface{}) erro
 	log.Print("Create Schema statement: " + createStatement)
 
 	if _, err := redshiftClient.Exec(createStatement); err != nil {
-		log.Fatal(err)
+		log.Print(err)
 		return err
 	}
 
@@ -93,7 +93,7 @@ func resourceRedshiftSchemaCreate(d *schema.ResourceData, meta interface{}) erro
 	err := redshiftClient.QueryRow("SELECT oid FROM pg_namespace WHERE nspname = $1", d.Get("schema_name").(string)).Scan(&oid)
 
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
 		return err
 	}
 
@@ -124,7 +124,7 @@ func readRedshiftSchema(d *schema.ResourceData, db *sql.DB) error {
 	err := db.QueryRow("select nspname, nspowner from pg_namespace where oid = $1", d.Id()).Scan(&schemaName, &owner)
 
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
 		return err
 	}
 
@@ -185,7 +185,7 @@ func resourceRedshiftSchemaDelete(d *schema.ResourceData, meta interface{}) erro
 	_, err := client.Exec(dropSchemaQuery)
 
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
 		return err
 	}
 

--- a/redshift/resource_redshift_schema_group_privilege.go
+++ b/redshift/resource_redshift_schema_group_privilege.go
@@ -126,7 +126,7 @@ func resourceRedshiftSchemaGroupPrivilegeCreate(d *schema.ResourceData, meta int
 
 	schemaName, schemaOwner, schemaErr := GetSchemaInfoForSchemaId(tx, d.Get("schema_id").(int))
 	if schemaErr != nil {
-		log.Fatal(schemaErr)
+		log.Print(schemaErr)
 		tx.Rollback()
 		return schemaErr
 	}
@@ -138,7 +138,7 @@ func resourceRedshiftSchemaGroupPrivilegeCreate(d *schema.ResourceData, meta int
 
 	groupName, groupErr := GetGroupNameForGroupId(tx, d.Get("group_id").(int))
 	if groupErr != nil {
-		log.Fatal(groupErr)
+		log.Print(groupErr)
 		tx.Rollback()
 		return groupErr
 	}
@@ -147,14 +147,14 @@ func resourceRedshiftSchemaGroupPrivilegeCreate(d *schema.ResourceData, meta int
 		var grantPrivilegeStatement = "GRANT " + strings.Join(grants[:], ",") + " ON ALL TABLES IN SCHEMA " + schemaName + " TO GROUP " + groupName
 
 		if _, err := tx.Exec(grantPrivilegeStatement); err != nil {
-			log.Fatal(err)
+			log.Print(err)
 			tx.Rollback()
 			return err
 		}
 
 		var defaultPrivilegesStatement = "ALTER DEFAULT PRIVILEGES IN SCHEMA " + schemaName + " GRANT " + strings.Join(grants[:], ",") + " ON TABLES TO GROUP " + groupName
 		if _, err := tx.Exec(defaultPrivilegesStatement); err != nil {
-			log.Fatal(err)
+			log.Print(err)
 			tx.Rollback()
 			return err
 		}
@@ -163,7 +163,7 @@ func resourceRedshiftSchemaGroupPrivilegeCreate(d *schema.ResourceData, meta int
 	if len(schemaGrants) > 0 {
 		var grantPrivilegeSchemaStatement = "GRANT " + strings.Join(schemaGrants[:], ",") + " ON SCHEMA " + schemaName + " TO GROUP " + groupName
 		if _, err := tx.Exec(grantPrivilegeSchemaStatement); err != nil {
-			log.Fatal(err)
+			log.Print(err)
 			tx.Rollback()
 			return err
 		}
@@ -283,14 +283,14 @@ func resourceRedshiftSchemaGroupPrivilegeUpdate(d *schema.ResourceData, meta int
 
 	schemaName, _, schemaErr := GetSchemaInfoForSchemaId(tx, d.Get("schema_id").(int))
 	if schemaErr != nil {
-		log.Fatal(schemaErr)
+		log.Print(schemaErr)
 		tx.Rollback()
 		return schemaErr
 	}
 
 	groupName, groupErr := GetGroupNameForGroupId(tx, d.Get("group_id").(int))
 	if groupErr != nil {
-		log.Fatal(groupErr)
+		log.Print(groupErr)
 		tx.Rollback()
 		return groupErr
 	}
@@ -340,14 +340,14 @@ func resourceRedshiftSchemaGroupPrivilegeDelete(d *schema.ResourceData, meta int
 
 	schemaName, _, schemaErr := GetSchemaInfoForSchemaId(tx, d.Get("schema_id").(int))
 	if schemaErr != nil {
-		log.Fatal(schemaErr)
+		log.Print(schemaErr)
 		tx.Rollback()
 		return schemaErr
 	}
 
 	groupName, groupErr := GetGroupNameForGroupId(tx, d.Get("group_id").(int))
 	if groupErr != nil {
-		log.Fatal(groupErr)
+		log.Print(groupErr)
 		tx.Rollback()
 		return groupErr
 	}

--- a/redshift/resource_redshift_user.go
+++ b/redshift/resource_redshift_user.go
@@ -122,7 +122,7 @@ func resourceRedshiftUserCreate(d *schema.ResourceData, meta interface{}) error 
 		} else if v.(string) == "RESTRICTED" {
 			createStatement += " SYSLOG ACCESS RESTRICTED "
 		} else {
-			log.Fatalf("%v is not a valid value for SYSLOG ACCESS", v)
+			log.Printf("%v is not a valid value for SYSLOG ACCESS", v)
 			panic(v.(string))
 		}
 	}
@@ -144,7 +144,7 @@ func resourceRedshiftUserCreate(d *schema.ResourceData, meta interface{}) error 
 
 	if err != nil {
 		log.Print("User does not exist in pg_user_info table")
-		log.Fatal(err)
+		log.Print(err)
 		return err
 	}
 
@@ -203,7 +203,7 @@ func readRedshiftUser(d *schema.ResourceData, tx *sql.Tx) error {
 
 	if err != nil {
 		log.Print("Reading user does not exist")
-		log.Fatal(err)
+		log.Print(err)
 		return err
 	}
 


### PR DESCRIPTION
Log fatal runs an os.exit(1) which is problematic because it is run here sometimes before DB rollbacks. 

https://golang.org/src/log/log.go?s=9553:9581#L307

Hashicorp recommends here that functions not call os.exit 

https://www.terraform.io/docs/extend/writing-custom-providers.html#error-handling-amp-partial-state


