### PR TITLE
Add schema data source

### DIFF
--- a/redshift/data_source_redshift_schema.go
+++ b/redshift/data_source_redshift_schema.go
@@ -7,11 +7,6 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-/*
-TODO
-Add database property. This will require a new connection since you can't have databse agnostic connections in redshift/postgres
-*/
-
 func dataSourceRedshiftSchema() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceRedshiftSchemaReadByName,

--- a/redshift/data_source_redshift_schema.go
+++ b/redshift/data_source_redshift_schema.go
@@ -31,7 +31,7 @@ func dataSourceRedshiftSchemaReadByName(d *schema.ResourceData, meta interface{}
 		owner int
 	)
 
-	name := d.Get("name").(string)
+	name := d.Get("schema_name").(string)
 	redshiftClient := meta.(*Client).db
 
 	err := redshiftClient.QueryRow("select oid, nspowner from pg_namespace where nspname = $1", name).Scan(&oid, &owner)

--- a/redshift/data_source_redshift_schema.go
+++ b/redshift/data_source_redshift_schema.go
@@ -1,0 +1,53 @@
+package redshift
+
+import (
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+/*
+TODO
+Add database property. This will require a new connection since you can't have databse agnostic connections in redshift/postgres
+*/
+
+func dataSourceRedshiftSchema() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceRedshiftSchemaReadByName,
+
+		Schema: map[string]*schema.Schema{
+			"schema_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"owner": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceRedshiftSchemaReadByName(d *schema.ResourceData, meta interface{}) error {
+	var (
+		oid   int
+		owner int
+	)
+
+	name := d.Get("name").(string)
+	redshiftClient := meta.(*Client).db
+
+	err := redshiftClient.QueryRow("select oid, nspowner from pg_namespace where nspname = $1", name).Scan(&oid, &owner)
+
+	if err != nil {
+		log.Print(err)
+		return err
+	}
+
+	d.SetId(strconv.Itoa(oid))
+	d.Set("owner", owner)
+
+	return err
+}

--- a/redshift/provider.go
+++ b/redshift/provider.go
@@ -2,9 +2,10 @@ package redshift
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
-	"log"
 )
 
 func Provider() terraform.ResourceProvider {
@@ -50,6 +51,9 @@ func Provider() terraform.ResourceProvider {
 			"redshift_database":               redshiftDatabase(),
 			"redshift_schema":                 redshiftSchema(),
 			"redshift_group_schema_privilege": redshiftSchemaGroupPrivilege(),
+		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"redshift_schema": dataSourceRedshiftSchema(),
 		},
 		ConfigureFunc: providerConfigure,
 	}


### PR DESCRIPTION
Add a `data.redshift_schema` data source to allow pulling of `oid` and `owner` via the schema name. This makes it easier to split database management responsibilities between terraform for only managing the users and permissions, and another source (e.g. sql scripts, alembic, etc.) for managing the schemas.