### PR TITLE
Bug Fix, Empty Group

### DIFF
--- a/redshift/resource_redshift_group.go
+++ b/redshift/resource_redshift_group.go
@@ -148,6 +148,7 @@ func readRedshiftGroup(d *schema.ResourceData, tx *sql.Tx) error {
 		for _, i := range userIdsAsString {
 			j, err := strconv.Atoi(i)
 			if err != nil {
+				panic(i)
 				panic(err)
 			}
 			userIdsAsInt = append(userIdsAsInt, j)

--- a/redshift/resource_redshift_group.go
+++ b/redshift/resource_redshift_group.go
@@ -141,7 +141,7 @@ func readRedshiftGroup(d *schema.ResourceData, tx *sql.Tx) error {
 
 	//Notes on postgres array types https://gist.github.com/adharris/4163702, eg startying with underscore _int4
 
-	if users.Valid {
+	if users.Valid && users.String != "" {
 		var userIdsAsString = strings.Split(users.String[1:len(users.String)-1], ",")
 		var userIdsAsInt = []int{}
 

--- a/redshift/resource_redshift_group.go
+++ b/redshift/resource_redshift_group.go
@@ -141,7 +141,7 @@ func readRedshiftGroup(d *schema.ResourceData, tx *sql.Tx) error {
 
 	//Notes on postgres array types https://gist.github.com/adharris/4163702, eg startying with underscore _int4
 
-	if users.Valid && users.String != "" {
+	if users.Valid && users.String != "{}" {
 		var userIdsAsString = strings.Split(users.String[1:len(users.String)-1], ",")
 		var userIdsAsInt = []int{}
 

--- a/redshift/resource_redshift_group.go
+++ b/redshift/resource_redshift_group.go
@@ -148,7 +148,6 @@ func readRedshiftGroup(d *schema.ResourceData, tx *sql.Tx) error {
 		for _, i := range userIdsAsString {
 			j, err := strconv.Atoi(i)
 			if err != nil {
-				panic(i)
 				panic(err)
 			}
 			userIdsAsInt = append(userIdsAsInt, j)


### PR DESCRIPTION
When removing the only user from a group, this code was failing because the db connection was returning an empty array "{}" instead of a null. This was causing the cast to integer a few lines down to fail with

 `panic: strconv.Atoi: parsing "": invalid syntax`

This PR changes the code to check for that case and enter the else branch to assign an empty array to the state.